### PR TITLE
refactor: Move all libraries installations out of init-local

### DIFF
--- a/init.el
+++ b/init.el
@@ -152,6 +152,7 @@
 (require 'init-org-roam)
 (require 'init-go)
 (require 'init-org-gtd)
+(require 'init-bibtex)
 
 ;; Extra packages which don't require any configuration
 

--- a/init.el
+++ b/init.el
@@ -153,6 +153,7 @@
 (require 'init-go)
 (require 'init-org-gtd)
 (require 'init-bibtex)
+(require 'init-org-brain)
 
 ;; Extra packages which don't require any configuration
 

--- a/lisp/init-bibtex.el
+++ b/lisp/init-bibtex.el
@@ -1,0 +1,14 @@
+;;; init-bibtex.el --- Personal configuration
+;;; Commentary:
+;;; Code:
+
+(require-package 'helm-bibtex)
+(require 'helm-bibtex)
+(setq helm-bibtex-bibliography "~/org/gtd/notes/references.bib" ;; where your references are stored
+      helm-bibtex-library-path "~/Documents/lib" ;; wnhere your pdfs etc are stored
+      helm-bibtex-notes-path "~/org/gtd/notes/notes.org" ;; where your notes are stored
+      bibtex-completion-bibliography "~/org/gtd/notes/references.bib" ;; writing completion
+      bibtex-completion-notes-path "~/org/gtd/notes/notes.org")
+
+(provide 'init-bibtex)
+;;; init-bibtex.el ends here

--- a/lisp/init-go.el
+++ b/lisp/init-go.el
@@ -6,6 +6,9 @@
 
 ;;; Code:
 
+(require-package 'go-mode)
+(require 'go-mode)
+
 (add-hook 'go-mode-hook 'eglot-ensure)
 
 (provide 'init-go)

--- a/lisp/init-misc.el
+++ b/lisp/init-misc.el
@@ -53,5 +53,117 @@
 (add-auto-mode 'conf-mode "^Procfile\\'")
 
 
+;;; Undo tree
+(require-package 'undo-tree)
+(global-undo-tree-mode)
+
+ ;;; pdf-tools
+(require-package 'pdf-tools)
+(setq pdf-misc-print-programm "/usr/bin/lpr"
+      pdf-misc-print-programm-args (quote ("-o media=Letter" "-o fitplot")))
+
+ ;;; Password store
+(require-package 'password-store-otp)
+
+ ;;; bongo
+(require-package 'bongo)
+
+;;; plantuml
+(require-package 'plantuml-mode)
+(require-package 'flycheck-plantuml)
+
+(with-eval-after-load 'flycheck
+  (require 'flycheck-plantuml)
+  (flycheck-plantuml-setup))
+(setq org-plantuml-jar-path "/Users/javier_gonzalez4/plantuml.jar")
+
+;;; sql
+(require-package 'sqlup-mode)
+(add-hook 'sql-mode-hook 'sqlup-mode)
+
+;;; org-noter
+(pdf-tools-install)
+
+;;; eww
+(setq browse-url-browser-function 'eww-browse-url)
+
+;;; editorconfig
+(require-package 'editorconfig)
+(editorconfig-mode 1)
+
+;;; org-kanban
+(require-package 'org-kanban)
+(require 'org-kanban)
+
+;;; hackernews
+(require-package 'hackernews)
+
+;;; anki-editor
+(require-package 'anki-editor)
+
+(setq max-specpdl-size 13000)
+
+(setq max-lisp-eval-depth 10000)
+
+;;; Quick fix org mode
+
+(org-babel-do-load-languages
+ 'org-babel-load-languages
+ '((R . t)
+   (ditaa . t)
+   (dot . t)
+   (emacs-lisp . t)
+   (gnuplot . t)
+   (haskell . nil)
+   (latex . t)
+   (ocaml . nil)
+   (octave . t)
+   (plantuml . t)
+   (python . t)
+   (ruby . t)
+   (screen . nil)
+   (shell . t)
+   (sql . t)
+   (sqlite . t)
+   (scheme . t)))
+
+(setq org-babel-python-command "python3")
+
+;;; epresent
+(require-package 'epresent)
+(require 'epresent)
+
+;;; Magit configuration to use password store
+(require 'auth-source-pass)
+(auth-source-pass-enable)
+(setq auth-sources '(password-store))
+(add-hook 'magit-process-find-password-functions
+          'magit-process-password-auth-source)
+
+
+(setq python-interpreter python-shell-interpreter)
+
+(require-package 'groovy-mode)
+
+;;; Install kubernetes
+
+(use-package kubernetes
+  :ensure t
+  :commands (kubernetes-overview)
+  :config
+  (setq kubernetes-poll-frequency 3600
+        kubernetes-redraw-frequency 3600))
+
+
+(add-to-list 'image-types 'svg)
+
+;;; For Logstash configuration files
+(require-package 'logstash-conf)
+(require 'logstash-conf)
+
+;;; Puppet master
+(require-package 'puppet-mode)
+(require 'puppet-mode)
+
 (provide 'init-misc)
 ;;; init-misc.el ends here

--- a/lisp/init-org-brain.el
+++ b/lisp/init-org-brain.el
@@ -1,0 +1,33 @@
+;;; init-org-brain.el --- Personal configuration
+;;; Commentary:
+
+;;; This knowledge repository is deprecated and should no longer be used
+;;; other than for references
+
+;;; Code:
+
+;;; org-brain
+(require-package 'use-package)
+(require 'use-package)
+
+(use-package org-brain :ensure t
+  :init
+  (setq org-brain-path "~/org/brain")
+  ;; For Evil users
+  (with-eval-after-load 'evil
+    (evil-set-initial-state 'org-brain-visualize-mode 'emacs))
+  :config
+  (bind-key "C-c b" 'org-brain-prefix-map org-mode-map)
+  (setq org-id-track-globally t)
+  (setq org-id-locations-file "~/.emacs.d/.org-id-locations")
+  (add-hook 'before-save-hook #'org-brain-ensure-ids-in-buffer)
+  (push '("b" "Brain" plain (function org-brain-goto-end)
+          "* %i%?" :empty-lines 1)
+        org-capture-templates)
+  (setq org-brain-visualize-default-choices 'all)
+  (setq org-brain-title-max-length 12)
+  (setq org-brain-include-file-entries nil
+        org-brain-file-entries-use-title nil))
+
+(provide 'init-org-brain)
+;;; init-org-brain.el ends here


### PR DESCRIPTION
## Motivation

The init-local.el file is meant for configurations specific on the machine that Emacs is currently running on. During years, I had my this file filled with installation of new libraries coupled with actual local configuration. In this PR I completed the relocation of all library installation specifics to their own el files or in `init-misc`.