### PR TITLE
feat: Ignore items in the tickler.org file

### DIFF
--- a/lisp/init-org-gtd.el
+++ b/lisp/init-org-gtd.el
@@ -28,6 +28,13 @@
          ((org-agenda-overriding-header "Office")
           (org-agenda-skip-function #'my-org-agenda-skip-all-siblings-but-first)))))
 
+;;; Do not include future items.
+(setq org-agenda-tags-todo-honor-ignore-options t)
+(setq org-agenda-skip-scheduled-if-done t)
+(setq org-agenda-skip-deadline-if-done t)
+(setq org-agenda-todo-ignore-scheduled 'future)
+(setq org-agenda-todo-ignore-deadlines 7)
+
 (defun my-org-agenda-skip-all-siblings-but-first ()
   "Skip all but the first non-done entry."
   (let (should-skip-entry)


### PR DESCRIPTION
I usually ignored the global todo buffer because it was too noisy, it had all of my todo items that were scheduled or had a deadline and for that reason it was not really useful.

I finally put up the time to fix that issue, read the documentation and search on the following blog to put that issue to an end: https://baty.net/posts/2023/09/hiding-scheduled-todo-items-in-org-mode/