### PR TITLE
feat: Add support for the Racket programing language

### DIFF
--- a/init.el
+++ b/init.el
@@ -155,6 +155,7 @@
 (require 'init-org-brain)
 (require 'init-scala)
 (require 'init-agent)
+(require 'init-racket)
 
 ;; Extra packages which don't require any configuration
 

--- a/lisp/init-racket.el
+++ b/lisp/init-racket.el
@@ -1,0 +1,39 @@
+;;; init-racket.el --- Basic support for programming in Racket -*- lexical-binding: t -*-
+;;; Commentary:
+;;; Code:
+
+(require-package 'geiser)
+(require-package 'geiser-racket)
+(setq geiser-active-implementations '(racket))
+
+(require-package 'paredit)
+(add-hook 'scheme-mode-hook 'enable-paredit-mode)
+(add-hook 'geiser-repl-mode-hook 'enable-paredit-mode)
+
+(setq-default scheme-program-name "racket")
+
+;; Auto-start Geiser when opening a .scm file (optional but helpful)
+(add-hook 'scheme-mode-hook 'geiser-mode)
+
+;; Use Rainbow Delimiters to keep track of nested parens
+(require-package 'rainbow-delimiters)
+(add-hook 'scheme-mode-hook 'rainbow-delimiters-mode)
+
+(setq geiser-racket--parameters-extra '())
+
+(defun geiser-racket--parameters ()
+  "Return a list with all parameters needed to start racket.
+This function uses `geiser-racket-init-file' if it exists."
+  (let ((init-file (and (stringp geiser-racket-init-file)
+                        (expand-file-name geiser-racket-init-file)))
+        (binary (geiser-racket--real-binary))
+        (rackdir geiser-racket-scheme-dir))
+    `("-i" "-q" ,@geiser-racket--parameters-extra "-S" ,rackdir
+      ,@(apply 'append (mapcar (lambda (p) (list "-S" p))
+                               geiser-racket-collects))
+      ,@(and (listp binary) (cdr binary))
+      ,@(and init-file (file-readable-p init-file) (list "-f" init-file))
+      "-f" ,(expand-file-name "geiser/startup.rkt" rackdir))))
+
+(provide 'init-racket)
+;;; init-racket.el ends here


### PR DESCRIPTION
## Description

Adds support for the Racket programming language. 

Racket is based on Scheme that it turns out to be the default language for the SCIP programming book. What I added is just a simple function that allows parameter mapping to the Racket launch arguments to allow setting the SCIP mode when tackling the programming problems on the book

Once I complete the book, it should be possible to leave the default parameters for pure Racket development. 
